### PR TITLE
Add support for webdav with url for jackrabbit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+dist
+target
+momo-*.jar

--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ Current build status: [![Build Status](https://buildhive.cloudbees.com/job/deceb
 
 Features/Benefits
 -------------------
-Momo is an open source (Apache license) tiny JCR Browser.   
-With Momo you can browse a JCR, you can view the item's properties. Momo comes with built-in viewers for images and xml files.    
-Also, you can query the JCR using XPath, SQL, JCR_SQL2 and JCR_JQOM. A query history is stored in the query-history.xml file and you can navigate in the query history from application.   
-All you must to do is to set some properties in the momo.properties file.  
+Momo is an open source (Apache license) tiny JCR Browser.
+With Momo you can browse a JCR, you can view the item's properties. Momo comes with built-in viewers for images and xml files.
+Also, you can query the JCR using XPath, SQL, JCR_SQL2 and JCR_JQOM. A query history is stored in the query-history.xml file and you can navigate in the query history from application.
+All you must to do is to set some properties in the momo.properties file.
 
-For the moment only (Local) Jackrabbit is supported (this is the only one I have been using) but I think that I can easily add support for ModeShape or other JCR implementations.  
-All operations are read-only in general (except for renaming or deleting a node from hierarchy tab). 
+For the moment only (Local) Jackrabbit is supported (this is the only one I have been using) but I think that I can easily add support for ModeShape or other JCR implementations.
+All operations are read-only in general (except for renaming or deleting a node from hierarchy tab).
 
 How to use
 -------------------
@@ -28,11 +28,11 @@ To run momo application you can follow these steps:
 
 ```
 mkdir dist
-cd dist 
+cd dist
 cp ../target/momo-*.zip .
 unzip momo-*.zip
 java -jar momo-*.jar
-```   
+```
 
 DON'T FORGET
 You must create a file momo.properties from momo-sample.properties
@@ -50,12 +50,12 @@ You can see some screenshots from application in [wiki page] (https://github.com
 License
 --------------
 Copyright 2013 Decebal Suiu
- 
+
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this work except in compliance with
 the License. You may obtain a copy of the License in the LICENSE file, or at:
- 
+
 http://www.apache.org/licenses/LICENSE-2.0
- 
+
 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.

--- a/momo-sample.properties
+++ b/momo-sample.properties
@@ -1,6 +1,9 @@
-# jackrabbit
+# ----- jackrabbit ------
+# To connect using webdav url, set `url`, otherwise set both `configFile` and `home` and do not set `url`
 #repository.configFile=/home/decebal/work/nextreports-oss/server/config/repository.xml
 #repository.home=/home/decebal/work/nextreports-oss/server/data
+#repository.url=http://localhost:8080/server
+# Username and password are optional
 #repository.username=decebal
 #repository.password=1
 

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
                     <optimize>true</optimize>
                 </configuration>
             </plugin>
-            
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
@@ -79,12 +79,12 @@
                     <tagNameFormat>release-@{project.version}</tagNameFormat>
                 </configuration>
             </plugin>
-            
+
             <plugin>
                 <artifactId>maven-resources-plugin</artifactId>
                 <version>2.4.3</version>
             </plugin>
-            
+
             <plugin>
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>2.4</version>
@@ -98,7 +98,7 @@
 					</archive>
 		        </configuration>
             </plugin>
-            			
+
  			<plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <version>2.3</version>
@@ -119,7 +119,7 @@
                         </goals>
                     </execution>
                 </executions>
-            </plugin>			
+            </plugin>
         </plugins>
     </build>
 
@@ -133,7 +133,7 @@
 			<groupId>org.swinglabs.swingx</groupId>
 			<artifactId>swingx-core</artifactId>
 			<version>1.6.5-1</version>
-		</dependency>    
+		</dependency>
 		<dependency>
 			<groupId>de.sciss</groupId>
 			<artifactId>jsyntaxpane</artifactId>
@@ -148,34 +148,49 @@
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-log4j12</artifactId>
 			<version>1.7.5</version>
-		</dependency>            
+		</dependency>
 		<dependency>
 			<groupId>log4j</groupId>
 			<artifactId>log4j</artifactId>
 			<version>1.2.16</version>
-		</dependency>            
+		</dependency>
 		<dependency>
 			<groupId>com.thoughtworks.xstream</groupId>
 			<artifactId>xstream</artifactId>
 			<version>1.4.4</version>
-		</dependency>            		
+		</dependency>
 		<dependency>
 			<groupId>javax.jcr</groupId>
 			<artifactId>jcr</artifactId>
 			<version>2.0</version>
-		</dependency>		
+		</dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.1</version>
+        </dependency>
 		<dependency>
 			<groupId>org.apache.jackrabbit</groupId>
 			<artifactId>jackrabbit-core</artifactId>
-			<version>2.6.3</version>
-		</dependency>            
+			<version>2.6.5</version>
+		</dependency>
+        <dependency>
+            <groupId>org.apache.jackrabbit</groupId>
+            <artifactId>jackrabbit-jcr2dav</artifactId>
+            <version>2.6.5</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.jackrabbit</groupId>
+            <artifactId>jackrabbit-spi</artifactId>
+            <version>2.6.5</version>
+        </dependency>
 		<dependency>
 			<groupId>org.apache.derby</groupId>
 			<artifactId>derby</artifactId>
 			<version>10.10.1.1</version>
 		</dependency>
 	</dependencies>
-	
+
     <profiles>
         <profile>
             <id>release-sign-artifacts</id>
@@ -204,5 +219,5 @@
             </build>
         </profile>
     </profiles>
-  
+
 </project>


### PR DESCRIPTION
Adds the option for specifying `url` instead of `configFile` and `home` in `momo.properties`.
Uses jcr2dav to connect to a standalone jackrabbit server.
Makes username/password optional.